### PR TITLE
Fix date picker update comparison

### DIFF
--- a/trending_arccheck.py
+++ b/trending_arccheck.py
@@ -108,7 +108,7 @@ def get_sorted_indices(some_list):
 
 
 def string_to_date_time(date_string):
-    return datetime.strptime(date_string, '%m/%d/%Y')
+    return datetime.strptime(date_string, '%m/%d/%Y').date()
 
 
 def get_control_limits(y):


### PR DESCRIPTION
[Picking a new date with the date picker ](https://github.com/cutright/IMRT-QA-Data-Miner/blob/master/trending_arccheck.py#L228) currently results in comparing a `datetime `object with a `date `object. 