### PR TITLE
Fix keys list when last element has whitespace

### DIFF
--- a/trending_arccheck.py
+++ b/trending_arccheck.py
@@ -30,7 +30,11 @@ def import_csv(file_path):
             raw_data.append(line.split(','))
 
     keys = raw_data.pop(0)
-    keys = [key.strip() for key in keys] + ['file_name']
+    keys = [key.strip() for key in keys]
+    if not keys[-1]:
+        keys[-1] = 'file_name'
+    else:
+        keys += ['file_name']
     data = {key: [] for key in keys}
     for row in raw_data:
         for col, key in enumerate(keys):

--- a/trending_delta4.py
+++ b/trending_delta4.py
@@ -30,7 +30,11 @@ def import_csv(file_path):
             raw_data.append(line.split(','))
 
     keys = raw_data.pop(0)
-    keys = [key.strip() for key in keys] + ['file_name']
+    keys = [key.strip() for key in keys]
+    if not keys[-1]:
+        keys[-1] = 'file_name'
+    else:
+        keys += ['file_name']
     data = {key: [] for key in keys}
     for row in raw_data:
         for col, key in enumerate(keys):


### PR DESCRIPTION
@cutright  Please review and test with your reports.

On my system, the last element in the [list of keys ](https://github.com/cutright/IMRT-QA-Data-Miner/blob/master/trending_arccheck.py#L32) is `'\r\n'`.

[On line 33](https://github.com/cutright/IMRT-QA-Data-Miner/blob/master/trending_arccheck.py#L33), after stripping the whitespace, the last element is now an empty string. But if you simply add `['file_name']`, this adds an extra column compared to the `raw_data`.