### PR TITLE
fix for issue 7

### DIFF
--- a/trending_arccheck.py
+++ b/trending_arccheck.py
@@ -17,10 +17,9 @@ from bokeh.models import HoverTool, ColumnDataSource, Select, Div, TextInput, Le
 from bokeh.layouts import column, row
 from bokeh.models.widgets import DatePicker, CheckboxButtonGroup
 import numpy as np
-from IQDM.utilities import string_to_date_time, collapse_into_single_dates, moving_avg, get_control_limits, import_csv
+from IQDM.utilities import collapse_into_single_dates, moving_avg, get_control_limits, import_csv
 
 FILE_PATH = r'results\arccheck_results_2019-12-31 09-04-33-036588_comp.csv'
-DATE_FORMAT = '%m/%d/%Y'
 
 
 class Plot:
@@ -65,7 +64,7 @@ class Plot:
         self.fig.title.align = 'center'
 
     def __set_x(self):
-        self.x = [string_to_date_time(d, DATE_FORMAT) for d in self.data['Plan Date']]
+        self.x = self.data['date_time_obj']
 
     def __add_plot_data(self):
         self.plot_data_1 = self.fig.circle('x', 'y', source=self.source[1]['plot'], color='blue', size=8, alpha=0.4)
@@ -317,7 +316,7 @@ class PlotControlChart:
         self.div_lcl.text = "<b>LCL</b>:"
 
 
-data = import_csv(FILE_PATH, DATE_FORMAT)
+data = import_csv(FILE_PATH)
 plot = Plot(data)
 ichart = PlotControlChart(plot)
 plot.ichart = ichart

--- a/trending_delta4.py
+++ b/trending_delta4.py
@@ -17,23 +17,20 @@ from bokeh.models import HoverTool, ColumnDataSource, Select, Div, TextInput, Le
 from bokeh.layouts import column, row
 from bokeh.models.widgets import DatePicker, CheckboxButtonGroup
 import numpy as np
-from IQDM.utilities import string_to_date_time, collapse_into_single_dates, moving_avg, get_control_limits, import_csv
+from IQDM.utilities import collapse_into_single_dates, moving_avg, get_control_limits, import_csv
 
 FILE_PATH = r'results\delta4_results_2020-01-02 12-22-20-554312.csv'  # UPDATE this for you, may need absolute path
 GROUPS = [1, 2]
 COLORS = {1: 'blue', 2: 'red'}
-# DATE_FORMAT = '%m/%d/%Y'
-DATE_FORMAT = '%Y-%m-%d'
 
 # TODO: Generalize for different parsers
 MAIN_PLOT_KEYS = ['x', 'y', 'id', 'gamma_crit', 'file_name', 'gamma_index', 'daily_corr', 'dta']
 
 
 class TrendingDashboard:
-    def __init__(self, file_path, date_format):
+    def __init__(self, file_path):
 
-        self.data = import_csv(file_path, date_format)
-        self.date_format = date_format
+        self.data = import_csv(file_path)
 
         self.__create_sources()
         self.__set_x()
@@ -69,7 +66,7 @@ class TrendingDashboard:
                                     'patch': ColumnDataSource(data=dict(x=[], y=[]))} for grp in GROUPS}
 
     def __set_x(self):
-        self.x = [string_to_date_time(d, date_format=self.date_format) for d in self.data['Plan Date']]
+        self.x = self.data['date_time_obj']
 
     def __create_figures(self):
 
@@ -195,7 +192,7 @@ class TrendingDashboard:
         self.div_lcl = {grp: Div(text='', width=175) for grp in GROUPS}
 
     def __create_widgets(self):
-        ignored_y = ['Patient Name', 'Patient ID', 'Plan Date', 'Radiation Dev', 'Energy', 'file_name']
+        ignored_y = ['Patient Name', 'Patient ID', 'Plan Date', 'Radiation Dev', 'Energy', 'file_name', 'date_time_obj']
         y_options = [option for option in list(self.data) if option not in ignored_y]
         self.select_y = Select(title='Y-variable:', value='Dose Dev', options=y_options)
 
@@ -400,6 +397,6 @@ class TrendingDashboard:
                 self.div_lcl[grp].text = "<b>LCL</b>:"
 
 
-dashboard = TrendingDashboard(FILE_PATH, DATE_FORMAT)
+dashboard = TrendingDashboard(FILE_PATH)
 curdoc().add_root(dashboard.layout)
 curdoc().title = "Delta 4 Trending"


### PR DESCRIPTION
Fix for Issue https://github.com/cutright/IMRT-QA-Data-Miner/issues/7

Moved the date parsing into `utilities.import_csv()`.  If `dateutil.parser.parse()` (imported as `date_parser`) fails, the date will be assumed to be today's date and the terminal will print which patient.

https://github.com/cutright/IMRT-QA-Data-Miner/blob/7eb50de8181e99041af6aef24f4f532cb9cc090e/IQDM/utilities.py#L156-L166

Also, `import_csv()` stores these datetime objects so that the trending script doesn't have to reparse the date strings:
https://github.com/cutright/IMRT-QA-Data-Miner/blob/7eb50de8181e99041af6aef24f4f532cb9cc090e/IQDM/utilities.py#L83-L93
